### PR TITLE
Updates mysql JDBC driver from 5.1.6 to 5.1.35

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 	<groupId>au.org.ala</groupId>
 	<artifactId>ala-cas</artifactId>
 	<packaging>war</packaging>
-	<version>1.3.2-SNAPSHOT</version>
+	<version>1.3.2</version>
 
 	<properties>
 		<cas.version>3.4.2</cas.version>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 	<groupId>au.org.ala</groupId>
 	<artifactId>ala-cas</artifactId>
 	<packaging>war</packaging>
-	<version>1.3.1</version>
+	<version>1.3.2-SNAPSHOT</version>
 
 	<properties>
 		<cas.version>3.4.2</cas.version>
@@ -61,7 +61,7 @@
 		<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
-			<version>5.1.6</version>
+			<version>5.1.35</version>
 			<scope>runtime</scope>
 		</dependency>
 		<!-- c3p0 Connection Pool -->


### PR DESCRIPTION
which proved to fix deadlock issues in userdetails app

deadlock issue details:

```
2015-06-25 23:31:59,303 INFO [org.jasig.cas.CentralAuthenticationServiceImpl] - <Granted service ticket [ST-42853-cdofZeKgeDfySAYLcyvp-cas] for service [http://images.ala.o
rg.au/image/proxyImageThumbnailLarge?imageId=9ebfa7bf-86ed-4f88-91b2-3d9e3a9e24af] for user [angel.ruiz@csiro.au]>
2015-06-25 23:31:59,305 WARN [org.hibernate.util.JDBCExceptionReporter] - <SQL Error: 1213, SQLState: 40001>
2015-06-25 23:31:59,305 ERROR [org.hibernate.util.JDBCExceptionReporter] - <Deadlock found when trying to get lock; try restarting transaction>
2015-06-25 23:31:59,305 ERROR [org.hibernate.event.def.AbstractFlushingEventListener] - <Could not synchronize database state with session>
org.hibernate.exception.LockAcquisitionException: Could not execute JDBC batch update
        at org.hibernate.exception.SQLStateConverter.convert(SQLStateConverter.java:107)
        at org.hibernate.exception.JDBCExceptionHelper.convert(JDBCExceptionHelper.java:66)
        at com.sun.proxy.$Proxy64.grantServiceTicket(Unknown Source)
        at org.jasig.cas.web.flow.GenerateServiceTicketAction.doExecute(GenerateServiceTicketAction.java:39)
        at org.springframework.webflow.action.AbstractAction.execute(AbstractAction.java:188)
Caused by: java.sql.BatchUpdateException: Deadlock found when trying to get lock; try restarting transaction
        at com.mysql.jdbc.PreparedStatement.executeBatchSerially(PreparedStatement.java:1666)
```
